### PR TITLE
Refactor RAUNet code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ stuff probably doesn't work at all for more exotic models like Cascade.
   was just patching a normal block, not actual cross-attention (so almost exactly like Deep Shrink). My version
   is implemented that way and does not patch cross-attention.
 * Customizable, but not very userfriendly. You get to figure out the blocks to patch!
-* Since ComfyUI doesn't allow applying a model patch for some of the RAUNet stuff, the patched Upscale/Downscale blocks
-  are _always_ active and will delegate to the original versions when RAUNet is disabled. This means having these nodes
-  loaded can break stuff even if you're not actually using them!
 * The list of caveats is too long, and it's probably not even complete. Yikes!
 
 ## Use with ControlNet
@@ -200,12 +197,7 @@ to input blocks with a low block number and output blocks with a high block numb
 normally supports. Not beneficial when generating at low resolutions (and actually likely harms quality).
 In other words, only use it when you have to.
 
-First, an important note: half of the RAUNet implementation is not a normal model patch. It globally patches
-ComfyUI. This means if you actually want to disable it after it's been enabled, you **must** execute the
-workflow once with the node toggled to disabled (at let execution reach that point). **Note**: If you don't
-do that, the RAUNet changes will be active even with the node disabled, muted or deleted entirely.
-
-Also note that you should only use one `ApplyRAUNet` node.
+You should only use one `ApplyRAUNet` node.
 
 As above, the default block values are for SD 1.5.
 

--- a/py/raunet.py
+++ b/py/raunet.py
@@ -1,78 +1,70 @@
+import logging
 import os
 import sys
+from functools import partial
+from inspect import signature
 
-import torch
+import torch.nn.functional as F  # noqa: N812
 from comfy.ldm.modules.diffusionmodules import openaimodel
-from comfy.ops import disable_weight_init
+from comfy.ldm.modules.diffusionmodules.openaimodel import ops
+from comfy.model_patcher import ModelPatcher
 
-from .utils import *
-
-nn = torch.nn
-F = nn.functional
-
-NO_CONTROLNET_WORKAROUND = (
-    os.environ.get("JANKHIDIFFUSION_NO_CONTROLNET_WORKAROUND") is not None
+from .utils import (
+    UPSCALE_METHODS,
+    check_time,
+    convert_time,
+    get_sigma,
+    parse_blocks,
+    scale_samples,
 )
-CONTROLNET_SCALE_ARGS = {"mode": "bilinear", "align_corners": False}
+
+NO_CONTROLNET_WORKAROUND = os.environ.get("JANKHIDIFFUSION_NO_CONTROLNET_WORKAROUND") is not None
+_PATCHED_FREEU = False
+_ORIG_FORWARD_TIMESTEP_EMBED = openaimodel.forward_timestep_embed
+_ORIG_APPLY_CONTROL = openaimodel.apply_control
 
 
-class HDConfigClass:
-    enabled = False
-    start_sigma = None
-    end_sigma = None
-    use_blocks = None
-    two_stage_upscale = True
-    upscale_mode = "bislerp"
+class HDConfig:
+    def __init__(self, start_sigma, end_sigma, use_blocks, two_stage_upscale, upscale_mode, two_stage_upscale_mode):
+        self.start_sigma = start_sigma
+        self.end_sigma = end_sigma
+        self.use_blocks = use_blocks
+        self.two_stage_upscale = two_stage_upscale
+        self.upscale_mode = upscale_mode
+        self.two_stage_upscale_mode = two_stage_upscale_mode
 
     def check(self, topts):
-        if not self.enabled or not isinstance(topts, dict):
-            return False
-        if topts.get("block") not in self.use_blocks:
+        if not isinstance(topts, dict) or topts.get("block") not in self.use_blocks:
             return False
         return check_time(topts, self.start_sigma, self.end_sigma)
 
 
-HDCONFIG = HDConfigClass()
+def hd_forward_timestep_embed(ts, x, emb, *args: list, **kwargs: dict):
+    transformer_options = kwargs.get("transformer_options", None)
+    output_shape = kwargs.get("output_shape", None)
+    transformer_options = args[1] if transformer_options is None and len(args) > 1 else {}
+    output_shape = args[2] if output_shape is None and len(args) > 2 else None
+    for layer in ts:
+        if isinstance(layer, openaimodel.Upsample) and "transformer_options" in signature(layer.forward).parameters:
+            x = layer.forward(
+                x,
+                output_shape=output_shape,
+                transformer_options=transformer_options,
+            )
+        elif isinstance(layer, openaimodel.Downsample) and "transformer_options" in signature(layer.forward).parameters:
+            x = layer.forward(x, transformer_options=transformer_options)
+        else:
+            x = _ORIG_FORWARD_TIMESTEP_EMBED((layer,), x, emb, *args, **kwargs)
+    return x
 
-ORIG_FORWARD_TIMESTEP_EMBED = openaimodel.forward_timestep_embed
-ORIG_APPLY_CONTROL = openaimodel.apply_control
 
-PATCHED_FREEU = False
-
-
-# Try to be compatible with FreeU Advanced.
-def try_patch_freeu_advanced():
-    global PATCHED_FREEU  # noqa: PLW0603
-    if PATCHED_FREEU:
-        return
-    # We only try one time.
-    PATCHED_FREEU = True
-    fua_nodes = sys.modules.get("FreeU_Advanced.nodes")
-    if not fua_nodes:
-        return
-
-    def fu_forward_timestep_embed(*args: list, **kwargs: dict):
-        fun = (
-            hd_forward_timestep_embed
-            if HDCONFIG.enabled
-            else ORIG_FORWARD_TIMESTEP_EMBED
-        )
-        return fun(*args, **kwargs)
-        if not HDCONFIG.enabled:
-            return ORIG_FORWARD_TIMESTEP_EMBED(*args, **kwargs)
-        return hd_forward_timestep_embed(*args, **kwargs)
-
-    def fu_apply_control(*args: list, **kwargs: dict):
-        fun = hd_apply_control if HDCONFIG.enabled else ORIG_APPLY_CONTROL
-        return fun(*args, **kwargs)
-
-    fua_nodes.forward_timestep_embed = fu_forward_timestep_embed
-    if not NO_CONTROLNET_WORKAROUND:
-        fua_nodes.apply_control = fu_apply_control
-    print("** jankhidiffusion: Patched FreeU_Advanced")
-
+def try_patch_forward_timestep_embed():
+    if openaimodel.forward_timestep_embed is not hd_forward_timestep_embed:
+        openaimodel.forward_timestep_embed = hd_forward_timestep_embed
 
 def hd_apply_control(h, control, name):
+    controlnet_scale_args = {"mode": "bilinear", "align_corners": False}
+
     ctrls = control.get(name) if control is not None else None
     if ctrls is None or len(ctrls) == 0:
         return h
@@ -80,128 +72,107 @@ def hd_apply_control(h, control, name):
     if ctrl is None:
         return h
     if ctrl.shape[-2:] != h.shape[-2:]:
-        print(
-            f"* jankhidiffusion: Scaling controlnet conditioning: {ctrl.shape[-2:]} -> {h.shape[-2:]}",
-        )
-        ctrl = F.interpolate(ctrl, size=h.shape[-2:], **CONTROLNET_SCALE_ARGS)
+        logging.info(f"* jankhidiffusion: Scaling controlnet conditioning: {ctrl.shape[-2:]} -> {h.shape[-2:]}")
+        ctrl = F.interpolate(ctrl, size=h.shape[-2:], **controlnet_scale_args)
     h += ctrl
     return h
 
 
 def try_patch_apply_control():
-    global ORIG_APPLY_CONTROL  # noqa: PLW0603
-    if openaimodel.apply_control is hd_apply_control or NO_CONTROLNET_WORKAROUND:
+    if openaimodel.apply_control is not hd_apply_control and not NO_CONTROLNET_WORKAROUND:
+        openaimodel.apply_control = hd_apply_control
+
+
+# Try to be compatible with FreeU Advanced.
+def try_patch_freeu_advanced():
+    global _PATCHED_FREEU  # noqa: PLW0603
+    if _PATCHED_FREEU:
         return
-    ORIG_APPLY_CONTROL = openaimodel.apply_control
-    openaimodel.apply_control = hd_apply_control
+
+    # We only try one time.
+    _PATCHED_FREEU = True
+    fua_nodes = sys.modules.get("FreeU_Advanced.nodes")
+    if not fua_nodes:
+        return
+
+    fua_nodes.forward_timestep_embed = hd_forward_timestep_embed
+    if not NO_CONTROLNET_WORKAROUND:
+        fua_nodes.apply_control = hd_apply_control
+    logging.info("** jankhidiffusion: Patched FreeU_Advanced")
 
 
-class NotFound:
-    pass
+def forward_upsample(_self, _forward, _hdconfig: HDConfig, x, output_shape=None, transformer_options=None):
+    if (
+        _self.dims == 3
+        or not _self.use_conv
+        or not _hdconfig.check(transformer_options)
+    ):
+        return _forward(x, output_shape=output_shape)
 
-
-def hd_forward_timestep_embed(ts, x, emb, *args: list, **kwargs: dict):
-    transformer_options = kwargs.get("transformer_options", NotFound)
-    output_shape = kwargs.get("output_shape", NotFound)
-    transformer_options = (
-        args[1] if transformer_options is NotFound and len(args) > 1 else {}
+    shape = (
+        output_shape[2:4]
+        if output_shape is not None
+        else (x.shape[2] * 4, x.shape[3] * 4)
     )
-    output_shape = args[2] if output_shape is NotFound and len(args) > 2 else None
-    for layer in ts:
-        if isinstance(layer, HDUpsample):
-            x = layer.forward(
-                x,
-                output_shape=output_shape,
-                transformer_options=transformer_options,
-            )
-        elif isinstance(layer, HDDownsample):
-            x = layer.forward(x, transformer_options=transformer_options)
-        else:
-            x = ORIG_FORWARD_TIMESTEP_EMBED((layer,), x, emb, *args, **kwargs)
-    return x
-
-
-OrigUpsample, OrigDownsample = openaimodel.Upsample, openaimodel.Downsample
-
-
-class HDUpsample(OrigUpsample):
-    def forward(self, x, output_shape=None, transformer_options=None):
-        if (
-            self.dims == 3
-            or not self.use_conv
-            or not HDCONFIG.check(transformer_options)
-        ):
-            return super().forward(x, output_shape=output_shape)
-        shape = (
-            output_shape[2:4]
-            if output_shape is not None
-            else (x.shape[2] * 4, x.shape[3] * 4)
-        )
-        if HDCONFIG.two_stage_upscale:
-            x = F.interpolate(x, size=(shape[0] // 2, shape[1] // 2), mode="nearest")
+    if _hdconfig.two_stage_upscale:
         x = scale_samples(
             x,
-            shape[1],
-            shape[0],
-            mode=HDCONFIG.upscale_mode,
+            shape[1] // 2,
+            shape[0] // 2,
+            mode=_hdconfig.two_stage_upscale_mode,
             sigma=get_sigma(transformer_options),
         )
-        return self.conv(x)
+    x = scale_samples(
+        x,
+        shape[1],
+        shape[0],
+        mode=_hdconfig.upscale_mode,
+        sigma=get_sigma(transformer_options),
+    )
+    return _self.conv(x)
 
 
-class HDDownsample(OrigDownsample):
-    COPY_OP_KEYS = (
+def forward_downsample(_self, _forward, _hdconfig: HDConfig, x, transformer_options=None):
+    if (
+        _self.dims == 3
+        or not _self.use_conv
+        or not _hdconfig.check(transformer_options)
+    ):
+        return _forward(x)
+
+    copy_op_keys = (
         "comfy_cast_weights",
         "weight_function",
         "bias_function",
         "weight",
         "bias",
     )
-
-    def __init__(self, *args: list, dtype=None, device=None, **kwargs: dict):
-        super().__init__(*args, dtype=dtype, device=device, **kwargs)
-        self.dtype = dtype
-        self.device = device
-        self.ops = kwargs.get("operations", disable_weight_init)
-
-    def forward(self, x, transformer_options=None):
-        if (
-            self.dims == 3
-            or not self.use_conv
-            or not HDCONFIG.check(transformer_options)
-        ):
-            return super().forward(x)
-        tempop = self.ops.conv_nd(
-            self.dims,
-            self.channels,
-            self.out_channels,
-            3,  # kernel size
-            stride=(4, 4),
-            padding=(2, 2),
-            dilation=(2, 2),
-            dtype=self.dtype,
-            device=self.device,
-        )
-        for k in self.COPY_OP_KEYS:
-            setattr(tempop, k, getattr(self.op, k))
-        return tempop(x)
-
-
-# Necessary to monkeypatch the built in blocks before any models are loaded.
-openaimodel.Upsample = HDUpsample
-openaimodel.Downsample = HDDownsample
+    tempop = ops.conv_nd(
+        _self.dims,
+        _self.channels,
+        _self.out_channels,
+        3,  # kernel size
+        stride=(4, 4),
+        padding=(2, 2),
+        dilation=(2, 2),
+        dtype=x.dtype,
+        device=x.device,
+    )
+    for k in copy_op_keys:
+        setattr(tempop, k, getattr(_self.op, k))
+    return tempop(x)
 
 
 class ApplyRAUNet:
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch"
-    CATEGORY = "model_patches"
+    CATEGORY = "model_patches/unet"
 
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "enabled": ("BOOLEAN", {"default": True}),
+                "model": ("MODEL",),
                 "input_blocks": ("STRING", {"default": "3"}),
                 "output_blocks": ("STRING", {"default": "8"}),
                 "time_mode": (
@@ -220,14 +191,13 @@ class ApplyRAUNet:
                 "ca_input_blocks": ("STRING", {"default": "4"}),
                 "ca_output_blocks": ("STRING", {"default": "8"}),
                 "ca_upscale_mode": (UPSCALE_METHODS,),
-                "model": ("MODEL",),
+                "two_stage_upscale_mode": (UPSCALE_METHODS, {"default": "nearest"}),
             },
         }
 
     def patch(
         self,
-        enabled,
-        model,
+        model: ModelPatcher,
         input_blocks,
         output_blocks,
         time_mode,
@@ -240,28 +210,18 @@ class ApplyRAUNet:
         ca_input_blocks,
         ca_output_blocks,
         ca_upscale_mode,
+        two_stage_upscale_mode,
     ):
-        global ORIG_FORWARD_TIMESTEP_EMBED  # noqa: PLW0603
         use_blocks = parse_blocks("input", input_blocks)
         use_blocks |= parse_blocks("output", output_blocks)
         ca_use_blocks = parse_blocks("input", ca_input_blocks)
         ca_use_blocks |= parse_blocks("output", ca_output_blocks)
 
         model = model.clone()
-        if not enabled:
-            HDCONFIG.enabled = False
-            if ORIG_FORWARD_TIMESTEP_EMBED is not None:
-                openaimodel.forward_timestep_embed = ORIG_FORWARD_TIMESTEP_EMBED
-            if (
-                openaimodel.apply_control is not ORIG_APPLY_CONTROL
-                and not NO_CONTROLNET_WORKAROUND
-            ):
-                openaimodel.apply_control = ORIG_APPLY_CONTROL
-            return (model,)
 
         ms = model.get_model_object("model_sampling")
 
-        HDCONFIG.start_sigma, HDCONFIG.end_sigma = convert_time(
+        start_sigma, end_sigma = convert_time(
             ms,
             time_mode,
             start_time,
@@ -302,30 +262,41 @@ class ApplyRAUNet:
                 sigma=sigma,
             ), hsp
 
+        hdconfig = HDConfig(start_sigma, end_sigma, use_blocks, two_stage_upscale, upscale_mode, two_stage_upscale_mode)
+
         model.set_model_input_block_patch(input_block_patch)
         model.set_model_output_block_patch(output_block_patch)
-        HDCONFIG.use_blocks = use_blocks
-        HDCONFIG.two_stage_upscale = two_stage_upscale
-        HDCONFIG.upscale_mode = upscale_mode
-        HDCONFIG.enabled = True
-        if openaimodel.forward_timestep_embed is not hd_forward_timestep_embed:
-            try_patch_freeu_advanced()
-            ORIG_FORWARD_TIMESTEP_EMBED = openaimodel.forward_timestep_embed
-            openaimodel.forward_timestep_embed = hd_forward_timestep_embed
+
+        for block_type, block_index in use_blocks:
+            blocks = getattr(model.model.diffusion_model, f"{block_type}_blocks")
+            block_name = f"hd_{block_type}_{block_index}"
+
+            if block_type == "input":
+                block = blocks[block_index][0]
+                model.add_object_patch(f"{block_name}.forward", partial(forward_downsample, block, block.forward, hdconfig))
+                setattr(model.model, block_name, block)
+            elif block_type == "output":
+                block = blocks[block_index][2]
+                model.add_object_patch(f"{block_name}.forward", partial(forward_upsample, block, block.forward, hdconfig))
+                setattr(model.model, block_name, block)
+
+        try_patch_forward_timestep_embed()
         try_patch_apply_control()
+        try_patch_freeu_advanced()
+
         return (model,)
 
 
 class ApplyRAUNetSimple:
     RETURN_TYPES = ("MODEL",)
-    FUNCTION = "go"
-    CATEGORY = "model_patches"
+    FUNCTION = "patch"
+    CATEGORY = "model_patches/unet"
 
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "enabled": ("BOOLEAN", {"default": True}),
+                "model": ("MODEL",),
                 "model_type": (("SD15", "SDXL"),),
                 "res_mode": (
                     (
@@ -346,15 +317,22 @@ class ApplyRAUNetSimple:
                         *UPSCALE_METHODS,
                     ),
                 ),
-                "model": ("MODEL",),
+                "two_stage_upscale_mode": (
+                    (
+                        "default",
+                        *UPSCALE_METHODS,
+                    ),
+                ),
             },
         }
 
-    def go(self, enabled, model_type, res_mode, upscale_mode, ca_upscale_mode, model):
+    def patch(self, model_type, res_mode, upscale_mode, ca_upscale_mode, two_stage_upscale_mode, model):
         if upscale_mode == "default":
             upscale_mode = "bicubic"
         if ca_upscale_mode == "default":
             ca_upscale_mode = "bicubic"
+        if two_stage_upscale_mode == "default":
+            two_stage_upscale_mode = "nearest"
         res = res_mode.split(" ", 1)[0]
         if model_type == "SD15":
             blocks = ("3", "8")
@@ -379,7 +357,6 @@ class ApplyRAUNetSimple:
                 time_range = (1.0, 0.0)
                 ca_time_range = (1.0, 0.0)
                 ca_blocks = ("", "")
-                enabled = False
             elif res == "high":
                 time_range = (0.0, 0.5)
                 ca_time_range = (1.0, 0.0)
@@ -390,16 +367,13 @@ class ApplyRAUNetSimple:
                 raise ValueError("Unknown res_mode")
         else:
             raise ValueError("Unknown model type")
-        if not enabled:
-            print("** ApplyRAUNetSimple: Disabled")
-            return (model.clone(),)
+
         prettyblocks = " / ".join(b if b else "none" for b in blocks)
         prettycablocks = " / ".join(b if b else "none" for b in ca_blocks)
-        print(
+        logging.info(
             f"** ApplyRAUNetSimple: Using preset {model_type} {res}: upscale {upscale_mode}, in/out blocks [{prettyblocks}], start/end percent {time_range[0]:.2}/{time_range[1]:.2}  |  CA upscale {ca_upscale_mode},  CA in/out blocks [{prettycablocks}], CA start/end percent {ca_time_range[0]:.2}/{ca_time_range[1]:.2}",
         )
         return ApplyRAUNet().patch(
-            True,  # noqa: FBT003
             model,
             *blocks,
             "percent",
@@ -409,6 +383,7 @@ class ApplyRAUNetSimple:
             *ca_time_range,
             *ca_blocks,
             ca_upscale_mode,
+            two_stage_upscale_mode,
         )
 
 

--- a/py/utils.py
+++ b/py/utils.py
@@ -3,7 +3,7 @@ import importlib
 import torch.nn.functional as torchf
 from comfy.utils import bislerp
 
-UPSCALE_METHODS = ("bicubic", "bislerp", "bilinear", "nearest-exact", "area")
+UPSCALE_METHODS = ("bicubic", "bislerp", "bilinear", "nearest-exact", "nearest", "area")
 
 
 def parse_blocks(name, s) -> set:


### PR DESCRIPTION
I've refactored RAUNet code: now it uses `add_object_patch` from ModelPatcher to patch and unpatch blocks, meaning it's safe to just delete/bypass RAUNet nodes - no need for `enable` input anymore.
I've also removed static HDCONFIG and added a new input `two_stage_upscale_mode` to both RAUNet nodes.