### PR TITLE
Allow all resolutions for MSW-MSA. Change default values for SDXL

### DIFF
--- a/py/msw_msa_attention.py
+++ b/py/msw_msa_attention.py
@@ -164,14 +164,8 @@ class ApplyMSWMSAAttention:
         _batch, features, _channels = n.shape
         orig_height, orig_width = orig_shape[-2:]
 
-        downsample_ratio = round(
-            ((orig_height * orig_width) // features) ** 0.5,
-        )
-        height, width = (
-            math.ceil(orig_height / downsample_ratio),
-            math.ceil(orig_width / downsample_ratio),
-        )
-        wheight, wwidth = math.ceil(height / 2), math.ceil(width // 2)
+        width, height = rescale_size(orig_width, orig_height, features)
+        wheight, wwidth = math.ceil(height / 2), math.ceil(width / 2)
 
         if shift == 0:
             shift_size = ShiftSize(0, 0)

--- a/py/raunet.py
+++ b/py/raunet.py
@@ -270,14 +270,14 @@ class ApplyRAUNet:
                     "STRING",
                     {
                         "default": "3",
-                        "tooltip": "Comma-separated list of input Downsample blocks. Default is for SD 1.5. The corresponding valid block from output_blocks must be set along with input.\nValid blocks for SD1.5: 3, 6, 9\nValid blocks for SDXL: 3, 6",
+                        "tooltip": "Comma-separated list of input Downsample blocks. Default is for SD 1.5. The corresponding valid block from output_blocks must be set along with input.\nValid blocks for SD1.5: 3, 6, 9\nValid blocks for SDXL: 3, 6. Original Hidiffusion implementation uses 6 for SDXL.",
                     },
                 ),
                 "output_blocks": (
                     "STRING",
                     {
                         "default": "8",
-                        "tooltip": "Comma-separated list of output Upsample blocks. Default is for SD 1.5. The corresponding valid block from input_blocks must be set along with output.\nValid blocks for SD1.5: 8, 5, 2\nValid blocks for SDXL: 5, 2",
+                        "tooltip": "Comma-separated list of output Upsample blocks. Default is for SD 1.5. The corresponding valid block from input_blocks must be set along with output.\nValid blocks for SD1.5: 8, 5, 2\nValid blocks for SDXL: 5, 2. Original Hidiffusion implementation uses 2 for SDXL.",
                     },
                 ),
                 "time_mode": (
@@ -340,14 +340,14 @@ class ApplyRAUNet:
                     "STRING",
                     {
                         "default": "4",
-                        "tooltip": "Comma separated list of input cross-attention blocks. Default is for SD1.x, for SDXL you can try using 2 (or just disable it).",
+                        "tooltip": "Comma separated list of input cross-attention blocks. Default is for SD1.x, for SDXL you can try using 5 (or just disable it).",
                     },
                 ),
                 "ca_output_blocks": (
                     "STRING",
                     {
                         "default": "8",
-                        "tooltip": "Comma-separated list of output cross-attention blocks. Default is for SD1.x, for SDXL you can try using 7 (or just disable it).",
+                        "tooltip": "Comma-separated list of output cross-attention blocks. Default is for SD1.x, for SDXL you can try using 4 (or just disable it).",
                     },
                 ),
                 "ca_upscale_mode": (
@@ -450,6 +450,7 @@ class ApplyRAUNet:
                 return F.avg_pool2d(
                     h,
                     kernel_size=(int(ca_downscale_factor), int(ca_downscale_factor)),
+                    ceil_mode=True,
                 )
             return scale_samples(
                 h,


### PR DESCRIPTION
This PR contains some modified changes from https://github.com/megvii-research/HiDiffusion/commit/defa26b73483052b826783924aad8b8a98a6422d (I've changed interpolation mode to "nearest-exact" as it produces less blurry images)
I've also looked into original hidiffusion implementaion and it seems like some of SDXL default values in these nodes can be adjusted to match the results from diffusers:
- MSW-MSA should be applied to input blocks `4,5` and output blocks `3,4,5`
Mappings from diffusers to comfyui:
```python
    modified_key['windown_attn_module_key'] = ['down_blocks.1.attentions.0.transformer_blocks.0', # input_blocks.4.1.transformer_blocks.0
                               'down_blocks.1.attentions.0.transformer_blocks.1', # input_blocks.4.1.transformer_blocks.1
                               'down_blocks.1.attentions.1.transformer_blocks.0', # input_blocks.5.1.transformer_blocks.0
                               'down_blocks.1.attentions.1.transformer_blocks.1', # input_blocks.5.1.transformer_blocks.1
                               'up_blocks.1.attentions.0.transformer_blocks.0', # output_blocks.3.1.transformer_blocks.0
                               'up_blocks.1.attentions.0.transformer_blocks.1', # output_blocks.3.1.transformer_blocks.1
                               'up_blocks.1.attentions.1.transformer_blocks.0', # output_blocks.4.1.transformer_blocks.0
                               'up_blocks.1.attentions.1.transformer_blocks.1', # output_blocks.4.1.transformer_blocks.1
                               'up_blocks.1.attentions.2.transformer_blocks.0', # output_blocks.5.1.transformer_blocks.0
                               'up_blocks.1.attentions.2.transformer_blocks.1'] # output_blocks.5.1.transformer_blocks.1
```
- Unlike SD1.5, for SDXL the priority of up/downsampler and cross-attention up/down is swapped (`down_module_key` is `downsampler_block` for SD1.5, but it's `cross_attn_down_block` for SDXL), so for SDXL it should be better to start first with just CA for smaller resolutions.
- RAUNet blocks should be adjusted as well - input/output should be 6/2 and ca_input/ca_output should be 5/4
Mappings from diffusers to comfyui:
```python
# ca_input_blocks, corresponds to input_blocks.4 input_blocks.5 input_blocks.6 
# in code it's used only once after block 4, and because of how comfyui applies these patches it should be set to 5
modified_key['down_module_key'] = ['down_blocks.1'] 

# input_blocks, corresponds to input_blocks.6.0.op, so it should be 6
modified_key['down_module_key_extra'] = ['down_blocks.1.downsamplers.0.conv']

# ca_output_blocks, corresponds to output_blocks.3 output_blocks.4 output_blocks.5
# in code it's used only once after block 4, in comfyui it's block 4
modified_key['up_module_key'] = ['up_blocks.1']

# output_blocks, corresponds to output_blocks.2.2.conv, so it's block 2
modified_key['up_module_key_extra'] = ['up_blocks.0.upsamplers.0.conv']
```